### PR TITLE
Fix the internal server issue when uploading file

### DIFF
--- a/backend/api/import_export_api.py
+++ b/backend/api/import_export_api.py
@@ -34,8 +34,13 @@ def upload_file():
         return response, 400
 
     users_col = get_col(project_name, "users")
-    requestor = users_col.find_one({'email': requestor_email},
-                                   {'$or': [{'isContributor': True}, {'isAdmin': True}]})
+    # need to figure out what's this or is about here   
+    requestor = users_col.find_one({
+        '$and' : [
+            {'email': requestor_email},
+            {'$or': [{'isContributor': True}, {'isAdmin': True}]}
+        ]
+    })
     if requestor is None:
         return user_unauthorised_response()
 


### PR DESCRIPTION
When checking if the user uplaods the file is allowed to do so, the mongodb thinks the "$or" is a file path,
and it returns an error saying "file path cannot starts with $".
Use a $and condition to wrap both conditions together solves this problem.