### PR TITLE
[CDL-002] fix firebase config problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Collaborative_content_coding
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lerna.js.org/)  
-Backend Status: [![Build Status](https://travis-ci.com/saddboys/Collaborative_content_coding.svg?branch=master)](https://travis-ci.com/saddboys/Collaborative_content_coding)
+Backend Status: [![Build Status](https://travis-ci.org/zyan225/Collaborative_content_coding.svg?branch=master)](https://travis-ci.org/zyan225/Collaborative_content_coding)
 
 ENVIRONMENT FILES:
 - Put the environment files (.env) within the /app and the /backend directories

--- a/app/src/components/Firebase/firebase.ts
+++ b/app/src/components/Firebase/firebase.ts
@@ -2,15 +2,15 @@ import app from 'firebase/app';
 import 'firebase/auth';
 import firebase from "firebase";
 
+// For Firebase JS SDK v7.20.0 and later, measurementId is optional
 const config = {
-    apiKey: "AIzaSyBjxqi-CKBglWGn4Dfj0rkY4-mtwP_nwMk",
-    authDomain: "collaborative-content-coding.firebaseapp.com",
-    databaseURL: "https://collaborative-content-coding.firebaseio.com",
-    projectId: "collaborative-content-coding",
-    storageBucket: "collaborative-content-coding.appspot.com",
-    messagingSenderId: "172478633646",
-    appId: "1:172478633646:web:004d73a6e1b65283b63f3f",
-    measurementId: "G-Y8T1KM5DSB"
+    apiKey: "AIzaSyBF8xcbg2ipLYEvwtbopRBuZeVf0o5yNSM",
+    authDomain: "collaborative-data-labelling.firebaseapp.com",
+    projectId: "collaborative-data-labelling",
+    storageBucket: "collaborative-data-labelling.appspot.com",
+    messagingSenderId: "622015500073",
+    appId: "1:622015500073:web:41715cfded3590c45c7138",
+    measurementId: "G-RV8EPBQNQ4"
 };
 
 class Firebase {

--- a/backend/main.py
+++ b/backend/main.py
@@ -13,7 +13,7 @@ app.register_blueprint(project_api.project_api)
 app.register_blueprint(user_api.user_api)
 app.register_blueprint(import_export_api.import_export_api)
 
-cred = credentials.Certificate("collaborative-content-coding-firebase-adminsdk-dpj86-0d9f3ad3d8.json")
+cred = credentials.Certificate("collaborative-data-labelling-firebase-adminsdk-95tuz-b0d97a170a.json")
 default_app = firebase_admin.initialize_app(cred)
 
 # Start listing users from the beginning, 1000 at a time.


### PR DESCRIPTION
Fix the Firebase credential name issue and config in the source code. 

Copy-paste from comment on issue [CDL-002]:
I did not receive this issue, however, I realised that the code config for firebase was not pushed to master (sorry about that).
The issue might be caused by the wrong config because the account in firebase was not correctly saved in the MongoDB atlas. 
To explain that, if there are three users in the firebase as shown in the picture below:
![image](https://user-images.githubusercontent.com/52368549/119250198-80a97100-bbf2-11eb-9937-1e30196699b0.png)

There must be three entries in the users.users collection, however, there are only two stored in the database.
![image](https://user-images.githubusercontent.com/52368549/119250220-a9ca0180-bbf2-11eb-89b9-a203050f30ee.png)

This entry is automatically created when the user signup. MongoDB uses these entries to match project created to each user, cause it cannot access information in the firebase directly. 

So to solve your problem, I will make a PR for the change in the Firebase config, and delete your account created to give you a fresh start. Once that PR is merged, you should able to create a project successfully. 