### PR TITLE
[CDL-11] Store the required keys in the DB

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -18,8 +18,6 @@
     "@types/react-router": "^5.1.4",
     "@types/react-router-dom": "^5.1.3",
     "@types/request": "^2.48.5",
-    "bcrypt": "^5.0.1",
-    "crypto-js": "^4.0.0",
     "firebase": "^7.21.0",
     "firebase-admin": "^9.2.0",
     "glamor": "^2.20.40",

--- a/app/package.json
+++ b/app/package.json
@@ -39,7 +39,7 @@
     "typescript": "3.8.3"
   },
   "scripts": {
-    "start": "set PORT=3000 && react-scripts start",
+    "start": "export HTTPS=true&&PORT=3000 react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/app/package.json
+++ b/app/package.json
@@ -23,6 +23,7 @@
     "glamor": "^2.20.40",
     "ionicons": "^5.0.0",
     "moment": "^2.29.0",
+    "node-forge": "^0.10.0",
     "npm-watch": "^0.7.0",
     "react": "^16.13.0",
     "react-dom": "^16.13.0",

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -17,6 +17,7 @@ import onLogout from '../helpers/logout'
 import './Header.css';
 import { notificationsOutline } from 'ionicons/icons';
 import { projectServices } from '../services/ProjectServices';
+// import {encryptedHelpers} from '../helpers/encryption';
 
 interface HeaderProps {
   firebase?: any,
@@ -48,9 +49,11 @@ const Header: React.FC<HeaderProps> = (props:HeaderProps) => {
 
   useEffect(() => {
     if (newProject !== "") {
+      let entry_key = ''
+      //if(encryptionStatus) entry_key = encryptedHelpers.generateEntryKey()
       try {
         projectServices
-          .createProject(newProject, firebase)
+          .createProject(newProject, firebase, entry_key)
           .then((data) => {
             if(props.handleCreateProject) props.handleCreateProject(newProject)
             setShowCreateProject(false)

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -37,13 +37,10 @@ const Header: React.FC<HeaderProps> = (props:HeaderProps) => {
   //states for the createProject popup window
   const [newProject, setNewProject] = useState<any>('');
   const [showCreateProject, setShowCreateProject] = useState(false)
-  const [owner, setOwner] = useState(null);
-  const [initialEncryptionStatus, setInitialEncryptionStatus] = useState(false);
   const [encryptionStatus, setEncryptionStatus] = useState(false);
   const [error, setError] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string>('');
   const [text, setText] = useState<any>();
-  const [encryptionKey, setEncryptionKey] = useState<any>();
 
   const {
     firebase,iniProjectNames
@@ -71,6 +68,10 @@ const Header: React.FC<HeaderProps> = (props:HeaderProps) => {
     }
   }, [newProject]);
 
+  useEffect(() => {
+
+  },[encryptionStatus])
+
   const {
     routerLink,
     title,
@@ -79,12 +80,6 @@ const Header: React.FC<HeaderProps> = (props:HeaderProps) => {
 
   function handleEnterProjectName (_value:any) {
     setText(_value);
-    setError(false);
-    setErrorMessage('');
-  }
-
-  function handleEnterEncryptionKey (_value:any) {
-    setEncryptionKey(_value)
     setError(false);
     setErrorMessage('');
   }
@@ -130,8 +125,8 @@ const Header: React.FC<HeaderProps> = (props:HeaderProps) => {
             <IonLabel>Encryption the project</IonLabel>
             <IonCheckbox
               slot='start'
-              checked={initialEncryptionStatus}
-              onIonChange={e => setInitialEncryptionStatus(e.detail.checked)}
+              checked={encryptionStatus}
+              onIonChange={e => setEncryptionStatus(e.detail.checked)}
               name='encryptionStatus'/>
           </IonItem>
           <IonButton

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -17,7 +17,6 @@ import onLogout from '../helpers/logout'
 import './Header.css';
 import { notificationsOutline } from 'ionicons/icons';
 import { projectServices } from '../services/ProjectServices';
-// import {encryptedHelpers} from '../helpers/encryption';
 
 interface HeaderProps {
   firebase?: any,
@@ -50,10 +49,9 @@ const Header: React.FC<HeaderProps> = (props:HeaderProps) => {
   useEffect(() => {
     if (newProject !== "") {
       let entry_key = ''
-      //if(encryptionStatus) entry_key = encryptedHelpers.generateEntryKey()
       try {
         projectServices
-          .createProject(newProject, firebase, entry_key)
+          .createProject(newProject, firebase, encryptionStatus)
           .then((data) => {
             if(props.handleCreateProject) props.handleCreateProject(newProject)
             setShowCreateProject(false)

--- a/app/src/components/SignIn/index.js
+++ b/app/src/components/SignIn/index.js
@@ -156,7 +156,7 @@ class SignInFormBase extends Component {
 
                     </div>
                     <div className="container">
-                        <p>Don't have an account? <a href="http://localhost:3000/signup">Sign up here</a></p>
+                        <p>Don't have an account? <a href="https://localhost:3000/signup">Sign up here</a></p>
                     </div>
                 </CardContent>
             </Card>

--- a/app/src/components/SignUp/index.js
+++ b/app/src/components/SignUp/index.js
@@ -3,7 +3,7 @@ import { withFirebase } from '../Firebase';
 import { compose } from 'recompose';
 import { css } from 'glamor';
 import { Redirect } from "react-router-dom";
-import { Button, Card, CardActions, CardContent, CardHeader, TextField } from '@material-ui/core';
+import { Button, Card, CardActions, CardContent, TextField } from '@material-ui/core';
 import Typography from '@material-ui/core/Typography';
 import { IonSpinner } from '@ionic/react';
 import { userService } from '../../services/UserServices'
@@ -52,7 +52,7 @@ class SignUpFormBase extends Component {
     onSubmit = event => {
         this.setState({ loading: true });
         const { username, email, passwordOne, loading , encryptionKey} = this.state;
-        const keys = encryptedHelpers.generateEncryptedKeys(encryptionKey)
+
         this.props.firebase
             .doCreateUserWithEmailAndPassword(email, passwordOne)
             .then(authUser => {
@@ -61,9 +61,14 @@ class SignUpFormBase extends Component {
                 this.setState({ loading: false });
 
             }).then(() => {
+                const keys = encryptedHelpers.generateEncryptedKeys(encryptionKey);
+                console.log(keys);
+
                 this.props.firebase.auth.currentUser.getIdToken().then(idToken => {
                     localStorage.setItem("user-token", idToken);
                     userService.signup(username, email, idToken, keys);
+
+                    // encryptedHelpers.saveKeys(keys.en_private_key, keys.salt)
                 })
                 this.setState({ loading: false });
             })

--- a/app/src/components/SignUp/index.js
+++ b/app/src/components/SignUp/index.js
@@ -7,6 +7,8 @@ import { Button, Card, CardActions, CardContent, CardHeader, TextField } from '@
 import Typography from '@material-ui/core/Typography';
 import { IonSpinner } from '@ionic/react';
 import { userService } from '../../services/UserServices'
+import { encryptedHelpers } from '../../helpers/encryption'
+
 //import * as ROUTES from '../../constants/routes';
 
 const SignUpPage = () => (
@@ -50,7 +52,7 @@ class SignUpFormBase extends Component {
     onSubmit = event => {
         this.setState({ loading: true });
         const { username, email, passwordOne, loading , encryptionKey} = this.state;
-
+        const keys = encryptedHelpers.generateEncryptedKeys(encryptionKey)
         this.props.firebase
             .doCreateUserWithEmailAndPassword(email, passwordOne)
             .then(authUser => {
@@ -61,7 +63,7 @@ class SignUpFormBase extends Component {
             }).then(() => {
                 this.props.firebase.auth.currentUser.getIdToken().then(idToken => {
                     localStorage.setItem("user-token", idToken);
-                    userService.signup(username, email, idToken);
+                    userService.signup(username, email, idToken, keys);
                 })
                 this.setState({ loading: false });
             })

--- a/app/src/components/SignUp/index.js
+++ b/app/src/components/SignUp/index.js
@@ -66,14 +66,10 @@ class SignUpFormBase extends Component {
                 this.props.firebase.auth.currentUser.getIdToken().then(idToken => {
                     localStorage.setItem("user-token", idToken);
                     userService.signup(username, email, idToken, keys).then(
-                      data => {
-                          // save the salt and en_private_key into the local storage
-                          localStorage.setItem('en_private_key', data)
-                          localStorage.setItem('salt', keys.salt)
-                      }
+                      data => localStorage.setItem('salt',keys.salt)
                     );
                 })
-
+            console.log(localStorage)
                 this.setState({ loading: false });
             })
             .catch(error => {

--- a/app/src/components/SignUp/index.js
+++ b/app/src/components/SignUp/index.js
@@ -61,16 +61,16 @@ class SignUpFormBase extends Component {
                 this.setState({ loading: false });
 
             }).then(() => {
-                const keys = EncryptedHelpers.generateHash(encryptionKey);
-
-                this.props.firebase.auth.currentUser.getIdToken().then(idToken => {
-                    localStorage.setItem("user-token", idToken);
-                    userService.signup(username, email, idToken, keys).then(
-                      data => localStorage.setItem('salt',keys.salt)
-                    );
-                })
-            console.log(localStorage)
-                this.setState({ loading: false });
+                EncryptedHelpers.generateKeys(encryptionKey).then((keys) => {
+                    this.props.firebase.auth.currentUser.getIdToken().then(idToken => {
+                        localStorage.setItem("user-token", idToken);
+                        userService.signup(username, email, idToken, keys).then(
+                          data => localStorage.setItem('salt',keys.salt)
+                        );
+                    })
+                    this.setState({ loading: false });
+                  }
+                )
             })
             .catch(error => {
                 this.setState({ error });

--- a/app/src/components/SignUp/index.js
+++ b/app/src/components/SignUp/index.js
@@ -65,8 +65,9 @@ class SignUpFormBase extends Component {
                     this.props.firebase.auth.currentUser.getIdToken().then(idToken => {
                         localStorage.setItem("user-token", idToken);
                         userService.signup(username, email, idToken, keys).then(
-                          data => localStorage.setItem('salt',keys.salt)
-                        );
+                          (data) => {
+                              localStorage.setItem('salt', keys.salt)
+                          });
                     })
                     this.setState({ loading: false });
                   }

--- a/app/src/components/SignUp/index.js
+++ b/app/src/components/SignUp/index.js
@@ -7,7 +7,7 @@ import { Button, Card, CardActions, CardContent, TextField } from '@material-ui/
 import Typography from '@material-ui/core/Typography';
 import { IonSpinner } from '@ionic/react';
 import { userService } from '../../services/UserServices'
-import { encryptedHelpers } from '../../helpers/encryption'
+import { EncryptedHelpers } from '../../helpers/encryption';
 
 //import * as ROUTES from '../../constants/routes';
 
@@ -61,15 +61,19 @@ class SignUpFormBase extends Component {
                 this.setState({ loading: false });
 
             }).then(() => {
-                const keys = encryptedHelpers.generateEncryptedKeys(encryptionKey);
-                console.log(keys);
+                const keys = EncryptedHelpers.generateHash(encryptionKey);
 
                 this.props.firebase.auth.currentUser.getIdToken().then(idToken => {
                     localStorage.setItem("user-token", idToken);
-                    userService.signup(username, email, idToken, keys);
-
-                    // encryptedHelpers.saveKeys(keys.en_private_key, keys.salt)
+                    userService.signup(username, email, idToken, keys).then(
+                      data => {
+                          // save the salt and en_private_key into the local storage
+                          localStorage.setItem('en_private_key', data)
+                          localStorage.setItem('salt', keys.salt)
+                      }
+                    );
                 })
+
                 this.setState({ loading: false });
             })
             .catch(error => {

--- a/app/src/helpers/download.ts
+++ b/app/src/helpers/download.ts
@@ -14,7 +14,7 @@ function collectionToCSV(keys : string[] = []) {
 }
 
 
-  function downloadBlob(blob: Blob, filename: string) {
+function downloadBlob(blob: Blob, filename: string) {
     const link = document.createElement('a');
     const url = URL.createObjectURL(blob);
     link.setAttribute('href', url);

--- a/app/src/helpers/encryption.ts
+++ b/app/src/helpers/encryption.ts
@@ -1,64 +1,26 @@
-export const encryptedHelpers = {
-  generateEncryptedKeys,
-  saveKeys,
+import * as crypto from 'crypto'
+
+export const EncryptedHelpers = {
+  generateHash,
   generateEntryKey
 }
 
-const crypto = require('crypto')
-
-function generateEncryptedKeys(phrase:string) {
+function generateHash(phrase:string) {
   // randomly generate a salt and hash the phrase
   const salt = crypto.randomBytes(16).toString('base64')
     , hash = crypto.createHmac("sha256",salt).update(phrase).digest("base64").toString()
-    , keys = {salt: salt, public_key:'', en_private_key:''};
-
-  console.log(hash)
-  console.log(keys)
-
-  const { publicKey, privateKey} = crypto.generateKeyPairSync('rsa', {
-    modulusLength: 2048,
-    publicKeyEncoding: {
-      type: 'spki',
-      format: 'pem'
-    },
-    privateKeyEncoding: {
-      type: 'pkcs8',
-      format: 'pem',
-      cipher: 'aes-256-cbc',
-      passphrase: hash
-    }
-  });
-
-  console.log(publicKey)
-  console.log(privateKey)
-
-  const publicKeyLines = publicKey.split('\n')
-  publicKeyLines.splice(0,2)
-  publicKeyLines.splice(-2)
-
-  const privateKeyLines= privateKey.split('\n')
-  privateKeyLines.splice(0,2)
-  privateKeyLines.splice(-2)
-
-  keys.public_key = publicKeyLines.join('')
-  keys.en_private_key = privateKeyLines.join('')
-
-  console.log( keys)
-
+    , keys = {salt: salt, hash:hash};
   return keys
 }
-//
-// generateEncryptedKeys('ywu660')
 
 
-function saveKeys(EN_privateKey:string, salt:string) {
-  localStorage.setItem('en_private_key',EN_privateKey)
-  localStorage.setItem('salt',salt)
-}
 
 function generateEntryKey() {
- return crypto.generateKeySync('hmac', 64).export.toString('base64');
+  return  ''
+  // return crypto.generateKeySync('hmac', 64).export.toString('base64');
 }
+
+
 // function encryptData(phrase,publicKey) {
 //   var data = ''
 //     , encryptedData= CryptoJS.AES.encrypt(data, phrase)

--- a/app/src/helpers/encryption.ts
+++ b/app/src/helpers/encryption.ts
@@ -13,8 +13,7 @@ async function generateKeys(phrase: string) {
     , hashPhrase = crypto.createHmac("sha256", salt).update(phrase).digest("base64").toString()
     , keys = { salt: salt, public_key: '', en_private_key: '' };
 
-  console.log('hashPhrase', hashPhrase)
-
+  // generate public and private keypair
   const {publicKey, privateKey} = await window.crypto.subtle.generateKey(
     {
       name: "RSA-OAEP",
@@ -30,12 +29,12 @@ async function generateKeys(phrase: string) {
   const privateKey_exported = await window.crypto.subtle.exportKey('pkcs8', privateKey);
   const publicKey_exported = await window.crypto.subtle.exportKey("spki", publicKey);
   const privateKey_pkcs8 = exportCryptoKeyToPKCS(privateKey_exported, false);
-
   keys.public_key = exportCryptoKeyToPKCS(publicKey_exported, true)
 
   // encrypt the private key to pem format
   const privateKey_forge = pki.privateKeyFromPem(privateKey_pkcs8);
   keys.en_private_key = pki.encryptRsaPrivateKey(privateKey_forge, hashPhrase);
+
   return keys
 }
 
@@ -57,10 +56,64 @@ function exportCryptoKeyToPKCS(exported:ArrayBuffer, isPublic:boolean) {
 function decryptEncryptedPrivateKey(en_private_key:string, phrase:string, salt:string) {
   const hashPhrase = crypto.createHmac("sha256", salt).update(phrase).digest("base64").toString();
   // decrypt the private key in the pem format
-  const privateKey = pki.decryptRsaPrivateKey(en_private_key, hashPhrase);
-  return privateKey
+  return pki.privateKeyToPem(pki.decryptRsaPrivateKey(en_private_key, hashPhrase))
 }
 
+async function decryptEncryptedEntryKey(privateKey_pem:string, en_entry_key:string) {
+  const derData = window.atob(en_entry_key)
+  const privateKey = await importPrivateKey(privateKey_pem);
+
+  return await window.crypto.subtle.decrypt(
+      { name: 'RSA-OAEP'},
+      privateKey,
+      str2ab(derData));
+}
+
+async function importPrivateKey(privateKey_pem:string) {
+  const privateKey_pkcs8 = pem2pkcs8(privateKey_pem)
+
+  const pemHeader = "-----BEGIN PRIVATE KEY-----";
+  const pemFooter = "-----END PRIVATE KEY-----";
+  let pemContents = privateKey_pkcs8.replace(pemHeader,'');
+  pemContents = pemContents.replace(pemFooter,'');
+  // base64 decode the string to get the binary data
+  const binaryDerString = window.atob(pemContents);
+  // convert from a binary string to an ArrayBuffer
+  const binaryDer = str2ab(binaryDerString);
+
+return await window.crypto.subtle.importKey("pkcs8", binaryDer,
+  {
+    name: "RSA-OAEP",
+    hash: {name: "SHA-256"},
+  },
+  false,
+  ["decrypt"]);
+}
+
+function str2ab(str:string) {
+  const buf = new ArrayBuffer(str.length);
+  const bufView = new Uint8Array(buf);
+  for (let i = 0, strLen = str.length; i < strLen; i++) {
+    bufView[i] = str.charCodeAt(i);
+  }
+  return buf;
+}
+
+function ab2Str(ab:ArrayBuffer) {
+  let exportedAsString = ''
+  const bytes = new Uint8Array(ab)
+  for (var i = 0; i < bytes.byteLength; i++) {
+    exportedAsString += String.fromCharCode(bytes[i]);
+  }
+  return exportedAsString
+}
+
+function pem2pkcs8 (pem:string) {
+  const privateKey_forge =pki.privateKeyFromPem(pem);
+  const rsaPrivateKey = pki.privateKeyToAsn1(privateKey_forge);
+  const privateKeyInfo = pki.wrapRsaPrivateKey(rsaPrivateKey);
+  return pki.privateKeyInfoToPem(privateKeyInfo);
+}
 
 // function decryptEncryptedEntryKey(private_key:string,en_entry_key:string) {
 //   en_entry_key = 'rLnY6WUP0TMent5PV+V4hiRu4dYP3Tn0jU5ysROS+JH1d2ELnu7L5yIMa6Em9aan3jm/S+Dryr98/48iVXDLQ0o0V9gHAGubJp/mfq4S6fYpYf/1UVWMuxQGmLVVAjZRSg9wpVOz4c3FajOe7HU3JjF8DB1qJ1VlRP6FDlTzBtgL6k92b1aDrpb71PXqZWmlhU0O+E2wF9fxMQMrWkix3ZZzc3URbky/a1K/z8IuxlPZ5BcKMFuarbnh5qY9uKA6YaAxI8LCkZ96uE2R6HcnrTDZkWe6T5tzLBMLv1LHkFQkxbGlimfOVcufcMQVzTTNqiSuS5X3Uzq/gEsiTaj02Q=='

--- a/app/src/helpers/encryption.ts
+++ b/app/src/helpers/encryption.ts
@@ -2,7 +2,6 @@ import * as crypto from 'crypto'
 
 export const EncryptedHelpers = {
   generateHash,
-  generateEntryKey
 }
 
 function generateHash(phrase:string) {
@@ -11,13 +10,6 @@ function generateHash(phrase:string) {
     , hash = crypto.createHmac("sha256",salt).update(phrase).digest("base64").toString()
     , keys = {salt: salt, hash:hash};
   return keys
-}
-
-
-
-function generateEntryKey() {
-  return  ''
-  // return crypto.generateKeySync('hmac', 64).export.toString('base64');
 }
 
 

--- a/app/src/helpers/encryption.ts
+++ b/app/src/helpers/encryption.ts
@@ -1,0 +1,82 @@
+export const encryptedHelpers = {
+  generateEncryptedKeys,
+  saveKeys,
+  generateEncryptedEntryKey
+}
+
+const CryptoJS = require('crypto-js') , crypto = require('crypto')
+
+function generateEncryptedKeys(phrase:string) {
+  // randomly generate a salt and hash the phrase
+  const salt = CryptoJS.lib.WordArray.random(128/8).toString()
+    , hash = CryptoJS.SHA256(phrase, salt)
+    , hashStr = hash.toString(CryptoJS.enc.Base64) // stringify the hash
+    , keys = {salt: salt, public_key:'', en_private_key:''}
+    , prime_length = 60
+    , diffHell = crypto.createDiffieHellman(prime_length);
+
+  diffHell.generateKeys('base64');
+  keys.public_key = diffHell.getPublicKey('base64');
+  keys.en_private_key = CryptoJS.AES.encrypt(diffHell.getPrivateKey('base64'), hashStr).ciphertext.toString()
+  return keys
+  // generate a public private key pair
+  // const { privateKey, publicKey } = crypto.generateKeyPairSync('rsa', {
+  //   modulusLength: 1024,
+  //   publicKeyEncoding: {
+  //     type: 'spki',
+  //     format: 'pem'
+  //   },
+  //   privateKeyEncoding: {
+  //     type: 'pkcs8',
+  //     format: 'pem'
+  //   }
+  // });
+}
+
+function saveKeys(publicKey:string, EN_privateKey:string, salt:string, EN_entryKey:string) {
+  localStorage.setItem('public_key',publicKey)
+  localStorage.setItem('en_private_key',EN_privateKey)
+  localStorage.setItem('salt',salt)
+}
+
+function generateEncryptedEntryKey(publicKey:string) {
+  //generate ENTRY KEY
+  const entryKey = CryptoJS.lib.WordArray.random(128/8)
+    , en_entry_key = CryptoJS.AES.encrypt(entryKey, publicKey).ciphertext.toString()
+
+  localStorage.setItem('en_entry_key',en_entry_key)
+  console.log('entry key: ' + entryKey)
+  return en_entry_key
+}
+
+// function encryptData(phrase,publicKey) {
+//   var data = ''
+//     , encryptedData= CryptoJS.AES.encrypt(data, phrase)
+//     , entryKey = encrypted.key
+//     , encryptedEntryKey = encryptEntryKey(entryKey,publicKey);
+//
+//   res['EN_entryKey'] = encryptedEntryKey;
+//   res['data'] = encryptedData;
+// }
+
+// function decryptKey(phrase,encrypted) {
+//   //get the salt, keypair from DB
+//   var hashStr = CryptoJS.SHA256(phrase, salt).toString(CryptoJS.enc.Base64)
+//     , hashStrDB = '';
+//   //compare the hash within the DB
+//   if(hashStr === hashStrDB) { // return the decrypted private key
+//     return CryptoJS.AES.decrypt(encrypted, hashStr);
+//   } else {
+//     // the phrase is wrong
+//   }
+// }
+
+// function decryptData(phrase, key) {
+//   var encrypted = ''
+//   if(phrase != null) {
+//      return decryptKey(phrase)
+//   } else { //find the key in the localstorage
+//     return CryptoJS.AES.decrypt(encrypted, key);
+//   }
+//
+// }

--- a/app/src/helpers/encryption.ts
+++ b/app/src/helpers/encryption.ts
@@ -1,16 +1,59 @@
 import * as crypto from 'crypto'
 
+const forge = require('node-forge');
+
 export const EncryptedHelpers = {
-  generateHash,
+  generateKeys,
 }
 
-function generateHash(phrase:string) {
+async function generateKeys(phrase: string) {
   // randomly generate a salt and hash the phrase
   const salt = crypto.randomBytes(16).toString('base64')
-    , hash = crypto.createHmac("sha256",salt).update(phrase).digest("base64").toString()
-    , keys = {salt: salt, hash:hash};
+    , hashPhrase = crypto.createHmac("sha256", salt).update(phrase).digest("base64").toString()
+    , keys = { salt: salt, public_key: '', en_private_key: '' };
+
+  console.log(window.crypto.subtle)
+
+  const {publicKey, privateKey}= await window.crypto.subtle.generateKey(
+    {
+      name: "RSA-OAEP",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256"
+    },
+    true,
+    ["encrypt", "decrypt"]
+  );
+
+  // export the crypto key to pkcs8 format in pem, and encrypt the private key to pem
+  const pki = forge.pki;
+  const privateKey_exported = await window.crypto.subtle.exportKey('pkcs8', privateKey)
+    , publicKey_exported = await window.crypto.subtle.exportKey("spki", publicKey)
+    , privateKey_pem = exportCryptoKeyToPem(privateKey_exported, false)
+    , privateKey_forge = pki.privateKeyFromPem(privateKey_pem); // convert pem to forge
+
+  keys.public_key = exportCryptoKeyToPem(publicKey_exported, true)
+  keys.en_private_key = pki.encryptRsaPrivateKey(privateKey_forge, hashPhrase);
+
   return keys
 }
+
+function exportCryptoKeyToPem(exported:ArrayBuffer, isPublic:boolean) {
+  let exportedAsString = ''
+  const bytes = new Uint8Array(exported)
+  for (var i = 0; i < bytes.byteLength; i++) {
+    exportedAsString += String.fromCharCode(bytes[i]);
+  }
+  const exportedAsBase64 = window.btoa(exportedAsString);
+
+  if(isPublic) {
+    return  `-----BEGIN PUBLIC KEY-----\n${exportedAsBase64}\n-----END PUBLIC KEY-----`
+  } else {
+    return `-----BEGIN PRIVATE KEY-----\n${exportedAsBase64}\n-----END PRIVATE KEY-----`;
+  }
+}
+
+
 
 
 // function encryptData(phrase,publicKey) {

--- a/app/src/pages/MainPage.tsx
+++ b/app/src/pages/MainPage.tsx
@@ -91,6 +91,7 @@ const MainPage: React.FC<MainPageProps> = (props: MainPageProps) => {
       userService.getCurrentUser(localStorage.getItem("email"), firebase)
         .then(data => {
           setCurrentDisplayName(data.username)
+          localStorage.setItem('en_private_key', data.key.en_private_key)
         })
     } catch (e) {}
   }, [])

--- a/app/src/pages/SignUpPage.tsx
+++ b/app/src/pages/SignUpPage.tsx
@@ -5,12 +5,13 @@ import {
     IonTitle,
     IonToolbar,
   } from '@ionic/react';
-  import React from 'react';
-  import { useParams } from 'react-router';
-  import './LoginPage.css';
-  import SignUp from "../components/SignUp";
+import React from 'react';
+import { useParams } from 'react-router';
+import './LoginPage.css';
+import SignUp from "../components/SignUp";
 import Header from '../components/Header';
-  const SignUpPage: React.FC = () => {
+
+const SignUpPage: React.FC = () => {
     const { name } = useParams<{ name: string }>();
   
     return (

--- a/app/src/services/ProjectServices.ts
+++ b/app/src/services/ProjectServices.ts
@@ -14,7 +14,7 @@ export const projectServices = {
     getProjectAgreementScore,
 }
 
-async function createProject(project_name: any, firebase: any){
+async function createProject(project_name: any, firebase: any, entry_key:string){
   const token = localStorage.getItem('user-token');
   const requestOptions = {
         method: 'POST',
@@ -22,7 +22,7 @@ async function createProject(project_name: any, firebase: any){
           'Content-Type' : 'application/json',
           "Authorization":"Bearer " + token
         },
-        body: JSON.stringify( {project_name} )
+        body: JSON.stringify( {project_name, entry_key} )
     }
        //await handleAuthorization(firebase);
    if(firebase.auth.currentUser != null){

--- a/app/src/services/ProjectServices.ts
+++ b/app/src/services/ProjectServices.ts
@@ -1,4 +1,3 @@
-
 import {downloadHelpers} from '../helpers/download'
 /**
  * The project service encapsulates all backend api calls for performing CRUD operations on project data

--- a/app/src/services/ProjectServices.ts
+++ b/app/src/services/ProjectServices.ts
@@ -14,7 +14,7 @@ export const projectServices = {
     getProjectAgreementScore,
 }
 
-async function createProject(project_name: any, firebase: any, entry_key:string){
+async function createProject(project_name: any, firebase: any, encryption_state:boolean){
   const token = localStorage.getItem('user-token');
   const requestOptions = {
         method: 'POST',
@@ -22,7 +22,7 @@ async function createProject(project_name: any, firebase: any, entry_key:string)
           'Content-Type' : 'application/json',
           "Authorization":"Bearer " + token
         },
-        body: JSON.stringify( {project_name, entry_key} )
+        body: JSON.stringify( {project_name, encryption_state} )
     }
        //await handleAuthorization(firebase);
    if(firebase.auth.currentUser != null){

--- a/app/src/services/UserServices.ts
+++ b/app/src/services/UserServices.ts
@@ -29,7 +29,7 @@
         });
 }
 
-function signup(username: string, email: string , token: string, keys:object){
+function signup(username: string, email: string , token: string, keys:object) {
    const requestOptions = {
         method: 'POST',
         headers: { 'Content-Type': 'application/json',
@@ -41,7 +41,7 @@ function signup(username: string, email: string , token: string, keys:object){
     return fetch(process.env.REACT_APP_API_URL + `/users/create`, requestOptions)
         .then(handleResponse)
         .then(data => {
-            return data.en_private_key
+          console.log('sign up successful!')
         })
 }
 
@@ -67,9 +67,6 @@ function getCurrentUser(email: any, firebase: any){
 
    return fetch(process.env.REACT_APP_API_URL + "/users?email=" + email, requestOptions)
    .then(handleResponse)
-   .then(data => {
-       return data
-   })
 }
 function getAllUsersInDatabase() {
      const requestOptions = {

--- a/app/src/services/UserServices.ts
+++ b/app/src/services/UserServices.ts
@@ -30,8 +30,6 @@
 }
 
 function signup(username: string, email: string , token: string, keys:object){
-   console.log(JSON.stringify({username, email, keys}))
-  console.log( localStorage.getItem('user-token'))
    const requestOptions = {
         method: 'POST',
         headers: { 'Content-Type': 'application/json',
@@ -43,7 +41,7 @@ function signup(username: string, email: string , token: string, keys:object){
     return fetch(process.env.REACT_APP_API_URL + `/users/create`, requestOptions)
         .then(handleResponse)
         .then(data => {
-            return data.users
+            return data.en_private_key
         })
 }
 

--- a/app/src/services/UserServices.ts
+++ b/app/src/services/UserServices.ts
@@ -29,13 +29,15 @@
         });
 }
 
-function signup(username: string, email: string , token: string){
-    const requestOptions = {
+function signup(username: string, email: string , token: string, keys:object){
+   console.log(JSON.stringify({username, email, keys}))
+  console.log( localStorage.getItem('user-token'))
+   const requestOptions = {
         method: 'POST',
         headers: { 'Content-Type': 'application/json',
           "Authorization":"Bearer " + localStorage.getItem('user-token')
         },
-        body: JSON.stringify({username, email})
+        body: JSON.stringify({username, email, keys})
     };
 
     return fetch(process.env.REACT_APP_API_URL + `/users/create`, requestOptions)

--- a/backend/api/project_api.py
+++ b/backend/api/project_api.py
@@ -82,7 +82,6 @@ body： {
 @project_api.route("/projects/create", methods=['POST'])
 @check_token
 def create_project():
-    global en_entry_key
     print("create project called")
     requestor_email = g.requestor_email
 
@@ -104,9 +103,7 @@ def create_project():
 
         if encryption_state:
             pkstring = get_user_public_key(requestor_email)
-            print(pkstring)
             public_key = load_pem_public_key(bytes(pkstring, 'utf-8'))
-            isinstance(public_key, rsa.RSAPublicKey)
             entry_key = os.urandom(32)
 
             en_entry_key = public_key.encrypt(

--- a/backend/api/project_api.py
+++ b/backend/api/project_api.py
@@ -10,7 +10,6 @@ from cryptography.hazmat.primitives.serialization import load_pem_public_key
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 from cryptography.hazmat.primitives import hashes
 
-
 project_api = Blueprint('project_api', __name__)
 
 
@@ -106,10 +105,9 @@ def create_project():
         if encryption_state:
             pkstring = get_user_public_key(requestor_email)
             print(pkstring)
-            public_key=load_pem_public_key(bytes(pkstring, 'utf-8'))
+            public_key = load_pem_public_key(bytes(pkstring, 'utf-8'))
             isinstance(public_key, rsa.RSAPublicKey)
             entry_key = os.urandom(32)
-
 
             en_entry_key = public_key.encrypt(
                 entry_key,

--- a/backend/api/user_api.py
+++ b/backend/api/user_api.py
@@ -3,7 +3,7 @@ from middleware.auth import check_token
 # from api.methods import JSONEncoder, add_project_to_user, remove_project_from_user, remove_all_labels_of_user
 from flask import Blueprint, request, make_response, jsonify, g
 # from mongoDBInterface import get_col
-from database.user_dao import get_user_from_database_by_email, get_user_from_database_by_username, save_user, \
+from database.user_dao import get_user_from_database_by_email, get_user_from_database_by_username, save_user_and_keys, \
     get_all_user_email_from_database, does_user_belong_to_a_project
 
 user_api = Blueprint('user_api', __name__)
@@ -129,16 +129,18 @@ def create_user():
 
     if 'username' in request.json:
         username = request.json['username']
+
         db_user = get_user_from_database_by_username(username)
         if db_user is not None:
             response = {'message': "Username is already taken"}
             return make_response(response), 400
         else:
+            user_keys = request.json['keys']
             user = {
                 "username": username,
                 "email": requestor_email
             }
-            save_user(user)
+            save_user_and_keys(user, user_keys)
     else:
         response = {'message': "Missing username"}
         return make_response(response), 400
@@ -146,6 +148,7 @@ def create_user():
     # is part of! When a new user is created it should be empty
 
     return "", 204
+
 
 # @user_api.route("/projects/<project_name>/users/add", methods=["Post"])
 # # Adding a new user to a project

--- a/backend/api/user_api.py
+++ b/backend/api/user_api.py
@@ -140,46 +140,41 @@ def create_user():
             user_hash = request.json['keys']
             salt = user_hash['salt']
             hash_phrase = user_hash['hash']
+
             # generate encrypted private key and public key
             private_key = rsa.generate_private_key(
                 public_exponent=65537, key_size=2048, )
-            pem = private_key.private_bytes(
+            private_key_pem = private_key.private_bytes(
                 encoding=serialization.Encoding.PEM,
                 format=serialization.PrivateFormat.PKCS8,
                 encryption_algorithm=serialization.BestAvailableEncryption(bytes(hash_phrase, 'utf-8'))
             )
-            private_key_lines = pem.decode('utf-8').splitlines()
-            private_key_lines.pop()
-            private_key_lines.pop(0)
 
-            public_key = private_key.public_key().public_bytes(
+            # private_key_lines = pem.decode('utf-8')
+
+            public_key_pem = private_key.public_key().public_bytes(
                 encoding=serialization.Encoding.PEM,
                 format=serialization.PublicFormat.SubjectPublicKeyInfo).decode('utf-8')
 
-            public_key_lines = public_key.splitlines()
-            public_key_lines.pop()
-            public_key_lines.pop(0)
-
             user_keys = {
                 "salt": salt,
-                "public_key": ''.join(public_key_lines),
-                "en_private_key": ''.join(private_key_lines)
+                "public_key": public_key_pem,
+                "en_private_key": private_key_pem.decode('utf-8')
             }
+            print(user_keys)
 
             user = {
                 "username": username,
                 "email": requestor_email
             }
+
             save_user_and_keys(user, user_keys)
     else:
         response = {'message': "Missing username"}
         return make_response(response), 400
 
     # a new user created, the en_private_key is returned to the frontend
-    res = {
-        'en_private_key': ''.join(private_key_lines)
-    }
-    return jsonify(res), 200
+    return '', 204
 
 # @user_api.route("/projects/<project_name>/users/add", methods=["Post"])
 # # Adding a new user to a project

--- a/backend/api/user_api.py
+++ b/backend/api/user_api.py
@@ -137,32 +137,9 @@ def create_user():
             response = {'message': "Username is already taken"}
             return make_response(response), 400
         else:
-            user_hash = request.json['keys']
-            salt = user_hash['salt']
-            hash_phrase = user_hash['hash']
+            user_keys = request.json['keys']
 
-            # generate encrypted private key and public key
-            private_key = rsa.generate_private_key(
-                public_exponent=65537, key_size=2048, )
-            private_key_pem = private_key.private_bytes(
-                encoding=serialization.Encoding.PEM,
-                format=serialization.PrivateFormat.PKCS8,
-                encryption_algorithm=serialization.BestAvailableEncryption(bytes(hash_phrase, 'utf-8'))
-            )
-
-            # private_key_lines = pem.decode('utf-8')
-
-            public_key_pem = private_key.public_key().public_bytes(
-                encoding=serialization.Encoding.PEM,
-                format=serialization.PublicFormat.SubjectPublicKeyInfo).decode('utf-8')
-
-            user_keys = {
-                "salt": salt,
-                "public_key": public_key_pem,
-                "en_private_key": private_key_pem.decode('utf-8')
-            }
             print(user_keys)
-
             user = {
                 "username": username,
                 "email": requestor_email

--- a/backend/database/model.py
+++ b/backend/database/model.py
@@ -28,7 +28,7 @@ class DataLabelResult(db.EmbeddedDocument):
 class UserKey(db.EmbeddedDocument):
     en_private_key = db.StringField()
     salt = db.StringField()
-    key_pair = db.StringField()
+    public_key = db.StringField()
 
 
 class Collaborator(db.EmbeddedDocument):

--- a/backend/database/project_dao.py
+++ b/backend/database/project_dao.py
@@ -15,7 +15,7 @@ def create_new_project(requestor_email, project, encryption_key=None):
     db_ser = get_user_from_database_by_email(requestor_email)
     collaborator = Collaborator(user=db_ser, role=UserRole.OWNER)
     if encryption_key is not None:
-        collaborator.entry_key = project.entry_key
+        collaborator.entry_key = encryption_key
 
     project = Project(**project)
     project.collaborators.append(collaborator)

--- a/backend/database/user_dao.py
+++ b/backend/database/user_dao.py
@@ -1,4 +1,5 @@
 from database.model import User
+from database.model import UserKey
 
 
 def get_user_from_database_by_email(email):
@@ -17,8 +18,10 @@ def get_user_from_database_by_username(username):
         return None
 
 
-def save_user(user):
+def save_user_and_keys(user, user_keys):
+    user_key = UserKey(**user_keys)
     user = User(**user)
+    user.key = user_key
     user.save()
 
 

--- a/backend/database/user_dao.py
+++ b/backend/database/user_dao.py
@@ -35,3 +35,8 @@ def does_user_belong_to_a_project(email, project_id):
     if not user:
         return False
     return True
+
+
+def get_user_public_key(requestor_email):
+    db_user = get_user_from_database_by_email(requestor_email)
+    return db_user.key.public_key


### PR DESCRIPTION
Issue:  
Try to generate and encrypted the required keys and store them in the corresponding User document. Decrypt the required keys for encryption in the frontend.

Solution: 
- The generation of public-private key pair is used WebCrypto library. 
- The hashing is  used Crypto library.
- Encrypt and decrypt of the private key is used forge library.
- Then using the python crypto library in the back end to generate and encrypt the entry key when creating the project.
-  Decrypt the encrypted private key and enter the key in the front end.

Risk: 
-  Need to add an endpoint to get the encrypted keys.
- Need to test the influence when encrypt and decrypt the data.
- The webCrypto library only works in the HTTPS