### PR TITLE
[CDL-011] Generate Entry key in frontend and store hash phrase in localStorage instead

### DIFF
--- a/app/src/components/SignUp/index.js
+++ b/app/src/components/SignUp/index.js
@@ -64,10 +64,6 @@ class SignUpFormBase extends Component {
                     this.props.firebase.auth.currentUser.getIdToken().then(idToken => {
                         localStorage.setItem("user-token", idToken);
                         userService.signup(username, email, idToken, keys)
-                          .then((data) => {
-                              localStorage.setItem('salt', keys.salt)
-                              localStorage.setItem('en_private_key', keys.en_private_key)
-                          });
                     })
                     this.setState({ loading: false });
                   }

--- a/app/src/components/SignUp/index.js
+++ b/app/src/components/SignUp/index.js
@@ -63,7 +63,7 @@ class SignUpFormBase extends Component {
                   .then((keys) => {
                     this.props.firebase.auth.currentUser.getIdToken().then(idToken => {
                         localStorage.setItem("user-token", idToken);
-                        userService.signup(username, email, idToken, keys)
+                        userService.signup(username, email, idToken, keys).then()
                     })
                     this.setState({ loading: false });
                   }

--- a/app/src/helpers/encryption.ts
+++ b/app/src/helpers/encryption.ts
@@ -109,7 +109,7 @@ return await window.crypto.subtle.importKey(
     name: "RSA-OAEP",
     hash: { name: "SHA-256"},
   },
-  false,
+  true,
   ["decrypt"]);
 }
 
@@ -125,15 +125,14 @@ async function importPublicKey(publicKey_pkcs:string) {
   const binaryDer = str2ab(binaryDerString);
 
   return await window.crypto.subtle.importKey(
-    "pkcs8",
+    "spki",
     binaryDer,
     {
       name: "RSA-OAEP",
-      hash: "SHA-256"
+      hash: {name: "SHA-256"},
     },
     true,
-    ["encrypt"]
-  );
+    ["encrypt"]);
 }
 
 function str2ab(str:string) {
@@ -201,7 +200,7 @@ async function getKeys(firebase:any) {
   if(en_private_key === null || salt === null) {
     EncryptionServices.getUserKeys(firebase).then((key) => {
       localStorage.setItem('en_private_key',key.en_private_key)
-      localStorage.setItem('salt',key.salt)
+      localStorage.setItem('salt', key.salt)
     })
   }
 }

--- a/app/src/services/ProjectServices.ts
+++ b/app/src/services/ProjectServices.ts
@@ -24,13 +24,14 @@ async function createProject(project_name: any, firebase: any, encryption_state:
 
   if(encryption_state) {
     //get public key
-    let publicKey = localStorage.getItem('public_key')
+    const publicKey = localStorage.getItem('public_key')
     if(publicKey == null || publicKey == '') {
       // get from the backend
       const userKey = await EncryptionServices.getUserKeys(firebase)
-      publicKey = userKey.publicKey
+      localStorage.setItem('public_key', userKey.public_key);
     }
-    en_entry_key = await EncryptedHelpers.generateEncryptedEntryKey(publicKey)
+
+    en_entry_key = await EncryptedHelpers.generateEncryptedEntryKey(localStorage.getItem('public_key'))
   }
 
 

--- a/app/src/services/ProjectServices.ts
+++ b/app/src/services/ProjectServices.ts
@@ -214,10 +214,8 @@ async function getDescriptionOfAProject(firebase: any, project_id: any) {
  }
 
  async function uploadDocuments(projectId : string, file : File, firebase: any, encryptStatus:boolean){
-    console.log(file)
-   
    if(encryptStatus) {
-     EncryptedHelpers.encryptData('ywu660', file, firebase, projectId).then(
+     EncryptedHelpers.encryptData(file, firebase, projectId).then(
        (r)  => {
          console.log(r)
        }

--- a/backend/api/project_api.py
+++ b/backend/api/project_api.py
@@ -130,23 +130,10 @@ def create_project():
     if not any((project.project_name == project_name and get_owner_of_the_project(project).email == requestor_email) for
                project in db_project):
         # TODO check if the project should be encrypted, if yes, generate encrypted entry key 
-        encryption_state = request.json['encryption_state']
-
-        if encryption_state:
-            pkstring = get_user_public_key(requestor_email)
-            public_key = load_pem_public_key(bytes(pkstring, 'utf-8'))
-            entry_key = os.urandom(32)
-
-            en_entry_key = public_key.encrypt(
-                entry_key,
-                padding.OAEP(
-                    mgf=padding.MGF1(algorithm=hashes.SHA256()),
-                    algorithm=hashes.SHA256(),
-                    label=None)
-            )
-            print(b64encode(entry_key).decode())
-            print(b64encode(en_entry_key).decode())
-            create_new_project(requestor_email, request.json, b64encode(en_entry_key).decode())
+        en_entry_key = request.json['en_entry_key']
+        print(en_entry_key)
+        if en_entry_key != '':
+            create_new_project(requestor_email, request.json, en_entry_key)
         else:
             create_new_project(requestor_email, request.json)
     else:

--- a/backend/api/project_api.py
+++ b/backend/api/project_api.py
@@ -1,4 +1,3 @@
-from bson import ObjectId
 from api.validation_methods import user_unauthorised_response
 from database.user_dao import does_user_belong_to_a_project, get_user_public_key, get_user_from_database_by_email
 from database.project_dao import create_new_project, get_all_projects_of_a_user, get_owner_of_the_project, \
@@ -7,11 +6,6 @@ from middleware.auth import check_token
 from database.model import Project
 from flask import Blueprint, request, make_response, g, jsonify
 import re
-import os
-from base64 import b64encode
-from cryptography.hazmat.primitives.serialization import load_pem_public_key
-from cryptography.hazmat.primitives.asymmetric import padding, rsa
-from cryptography.hazmat.primitives import hashes
 
 project_api = Blueprint('project_api', __name__)
 

--- a/backend/api/project_api.py
+++ b/backend/api/project_api.py
@@ -115,6 +115,7 @@ def create_project():
     print("create project called")
     requestor_email = g.requestor_email
 
+    print(request.json)
     if 'project_name' in request.json:
         project_name = request.json['project_name']
     else:
@@ -131,11 +132,14 @@ def create_project():
                project in db_project):
         # TODO check if the project should be encrypted, if yes, generate encrypted entry key 
         en_entry_key = request.json['en_entry_key']
-        print(en_entry_key)
+        js = request.json
+        del js['en_entry_key']
+        print(js)
         if en_entry_key != '':
-            create_new_project(requestor_email, request.json, en_entry_key)
+
+            create_new_project(requestor_email, js, en_entry_key)
         else:
-            create_new_project(requestor_email, request.json)
+            create_new_project(requestor_email, js)
     else:
         response = {'message': "Project already exists"}
         return make_response(response), 400


### PR DESCRIPTION
Issue:
From the security perspective, move the generation of the encrypted entry key in the frontend.
To increase the usability, store the hash phrase in the localStorage instead of the salt. If the localStorage is clear, get the salt from the backend and ask users to enter the phrase again. 

Solution:
- Generate and encrypt entry key in the front end

Risk:
-  Need to trigger a UI to ask the user's phrase

Reviewed By:
Emily Yang