### PR TITLE
[CDL-011] Move generate keys to creating project 

### DIFF
--- a/app/src/components/Header.css
+++ b/app/src/components/Header.css
@@ -5,3 +5,25 @@
 ion-header img {
 	max-height: 56px;
 }
+
+ion-modal.auto-height {
+    --height: auto;
+    --width: auto;
+}
+
+ion-modal.auto-height .ion-page {
+    position: relative;
+    display: block;
+    contain: content;
+    padding: 26px;
+}
+
+ion-modal.auto-height .inner-content {
+    max-height: 80vh;
+    overflow: auto;
+    padding: 10px;
+}
+
+ion-modal.auto-height ion-button {
+    margin: 8px;
+}

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -98,7 +98,6 @@ const Header: React.FC<HeaderProps> = (props:HeaderProps) => {
         }
       }
     }
-    console.log('hello')
     checkFirstTime().then();
   },[])
 

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -9,7 +9,7 @@ import {
   IonLabel,
   IonInput,
   IonModal,
-  IonCheckbox, IonTitle,
+  IonCheckbox, IonTitle, IonText,
 } from '@ionic/react';
 import { add, addOutline } from 'ionicons/icons';
 import React, { useEffect, useState } from 'react';
@@ -40,10 +40,11 @@ const Header: React.FC<HeaderProps> = (props:HeaderProps) => {
   const [encryptionStatus, setEncryptionStatus] = useState(false);
   const [error, setError] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string>('');
-  const [text, setText] = useState<any>();
+  const [projectName, setProjectName] = useState<any>();
+  const [phrase, setPhrase] = useState<any>();
 
   const {
-    firebase,iniProjectNames
+    firebase
   } = props;
 
   useEffect(() => {
@@ -51,7 +52,7 @@ const Header: React.FC<HeaderProps> = (props:HeaderProps) => {
       let entry_key = ''
       try {
         projectServices
-          .createProject(newProject, firebase, encryptionStatus)
+          .createProject(newProject, firebase, encryptionStatus, phrase)
           .then((data) => {
             if(props.handleCreateProject)
               props.handleCreateProject(newProject)
@@ -85,9 +86,15 @@ const Header: React.FC<HeaderProps> = (props:HeaderProps) => {
   } = props;
 
   function handleEnterProjectName (_value:any) {
-    setText(_value);
+    setProjectName(_value);
     setError(false);
     setErrorMessage('');
+  }
+
+  function handleEnterPhrase(_value:any) {
+    setPhrase(_value)
+    setError(false);
+    setErrorMessage('')
   }
 
   function handleSubmit(e:React.FormEvent) {
@@ -97,7 +104,7 @@ const Header: React.FC<HeaderProps> = (props:HeaderProps) => {
     const formData = new FormData(e.target as HTMLFormElement);
     setNewProject(formData.get('projectName'));
     formData.delete('projectName');
-    setText("")
+    setProjectName("")
   }
 
   return (
@@ -106,20 +113,23 @@ const Header: React.FC<HeaderProps> = (props:HeaderProps) => {
       <IonModal
         isOpen={showCreateProject}
         cssClass='createProject'
-        onDidDismiss={() => setShowCreateProject(false)}
+        onDidDismiss={() => {
+          setShowCreateProject(false)
+          setEncryptionStatus(false)
+        }}
         backdropDismiss
       >
         <form
           onSubmit={(e: React.FormEvent) => {
             handleSubmit(e)
           }}
-          style={{'margin':'10px','height':'100%'}}
+          style={{'margin':'50px'}}
         >
           <IonTitle >New Project</IonTitle>
           <IonItem>
             <IonInput
               placeholder="Enter Project Name"
-              value={text}
+              value={projectName}
               name="projectName"
               id="projectName"
               onIonChange={(e) =>
@@ -136,8 +146,27 @@ const Header: React.FC<HeaderProps> = (props:HeaderProps) => {
               onIonChange={e => setEncryptionStatus(e.detail.checked)}
               name='encryptionStatus'/>
           </IonItem>
+          { encryptionStatus &&
+          <IonItem>
+            <IonInput
+              placeholder="Enter the phrase to encrypt data"
+              value={phrase}
+              name="encryptPhrase"
+              id="encryptPhrase"
+              onIonChange={(e) =>
+                handleEnterPhrase(e.detail.value)
+              }
+              type="password"
+            />
+          </IonItem> }
+          { encryptionStatus &&
+          <IonItem>
+            <p className='encryption' >Encryption is used to ensure the data is kept private from the tool maintainers.
+              <IonText color="danger"><a>You must remember the encryption phrase.</a></IonText>
+            </p>
+          </IonItem> }
           <IonButton
-            disabled={text == null || text.length < 1}
+            disabled={projectName == null || projectName.length < 1}
             fill="outline"
             type="submit"
             expand="block"

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -57,7 +57,7 @@ const Header: React.FC<HeaderProps> = (props:HeaderProps) => {
         if(encryptionStatus && firstTimeEncrypt) {
           EncryptedHelpers.generateKeys(phrase).then((userKey) => {
             EncryptionServices.storeCurrentUserkey(userKey, firebase).then(r=> {
-              console.log(r)
+              setFirstTimeEncrypt(false);
             })
           })
         }

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -98,8 +98,9 @@ const Header: React.FC<HeaderProps> = (props:HeaderProps) => {
         }
       }
     }
+    console.log('hello')
     checkFirstTime().then();
-  },[encryptionStatus])
+  },[])
 
   const {
     routerLink,

--- a/app/src/components/SignUp/index.js
+++ b/app/src/components/SignUp/index.js
@@ -38,7 +38,6 @@ const INITIAL_STATE = {
     error: null,
     redirect: null,
     loading: false,
-    encryptionKey: ''
 };
 
 class SignUpFormBase extends Component {
@@ -49,7 +48,7 @@ class SignUpFormBase extends Component {
 
     onSubmit = event => {
         this.setState({ loading: true });
-        const { username, email, passwordOne, loading , encryptionKey} = this.state;
+        const { username, email, passwordOne, loading} = this.state;
 
         this.props.firebase
             .doCreateUserWithEmailAndPassword(email, passwordOne)
@@ -59,15 +58,11 @@ class SignUpFormBase extends Component {
                 this.setState({ loading: false });
 
             }).then(() => {
-                EncryptedHelpers.generateKeys(encryptionKey)
-                  .then((keys) => {
-                    this.props.firebase.auth.currentUser.getIdToken().then(idToken => {
-                        localStorage.setItem("user-token", idToken);
-                        userService.signup(username, email, idToken, keys).then()
-                    })
-                    this.setState({ loading: false });
-                  }
-                )
+                this.props.firebase.auth.currentUser.getIdToken().then(idToken => {
+                    localStorage.setItem("user-token", idToken);
+                    userService.signup(username, email, idToken).then()
+                })
+            this.setState({ loading: false });
             })
             .catch(error => {
                 this.setState({ error });
@@ -89,15 +84,13 @@ class SignUpFormBase extends Component {
             passwordTwo,
             error,
             loading,
-           encryptionKey,
         } = this.state;
 
         const isInvalid =
             passwordOne !== passwordTwo ||
             passwordOne === '' ||
             email === '' ||
-            username === '' ||
-            encryptionKey === '';
+            username === '';
         if (this.state.redirect) {
             return <Redirect to={this.state.redirect} />
         }
@@ -153,24 +146,6 @@ class SignUpFormBase extends Component {
                                     type="password"
                                     placeholder="Confirm Password"
                                 />
-                            </div>
-                            <div {...inputBoxStyling}>
-                                <TextField
-                                  style={{ maxWidth: '400px', minWidth: '270px' }}
-                                  name="encryptionKey"
-                                  value={encryptionKey}
-                                  onChange={this.onChange}
-                                  onFocus={(e) => {
-                                      var ps = document.getElementsByClassName('encryption')
-                                      for(var x=0; x< ps.length; x++) {
-                                          ps[x].style.visibility = 'visible'
-                                      }
-                                  }}
-                                  type="password"
-                                  placeholder="Confirm encryption key"
-                                />
-                                <p className='encryption' style={{visibility:'hidden'}}>Encryption is used to ensure the data is kept private from the tool maintainers.</p>
-                                <p className='encryption' style={{visibility: 'hidden', color:'red'}}>Please remember your encryption key.</p>
                             </div>
                             <div {...inputBoxStyling}>
                                 <CardActions>

--- a/app/src/pages/MainPage.css
+++ b/app/src/pages/MainPage.css
@@ -1,25 +1,3 @@
- 
-  ion-modal.auto-height {
-    --height: auto;
-    --width: auto;
-  }
-  
-  ion-modal.auto-height .ion-page {
-    position: relative;
-    display: block;
-    contain: content;
-    padding: 26px;
-  }
-  
-  ion-modal.auto-height .inner-content {
-    max-height: 80vh;
-    overflow: auto;
-    padding: 10px;
-  }
-  
-  ion-modal.auto-height ion-button {
-    margin: 8px;
-  }
 
   ion-card-title {
     padding: 16px;
@@ -58,11 +36,4 @@
       padding: 20px;
       font-size: 40px;
       text-align: center;
-  }
-
-  .createProject{
-    --width: 35%;
-    --height: 30%;
-    --border-style:none;
-    --border-width: 10px;
   }

--- a/app/src/pages/MainPage.tsx
+++ b/app/src/pages/MainPage.tsx
@@ -91,7 +91,6 @@ const MainPage: React.FC<MainPageProps> = (props: MainPageProps) => {
       userService.getCurrentUser(localStorage.getItem("email"), firebase)
         .then(data => {
           setCurrentDisplayName(data.username)
-          localStorage.setItem('en_private_key', data.key.en_private_key)
         })
     } catch (e) {}
   }, [])

--- a/app/src/services/EncryptionService.ts
+++ b/app/src/services/EncryptionService.ts
@@ -9,16 +9,14 @@ export const EncryptionServices = {
 async function getUserKeys(firebase: any) {
   await handleAuthorization(firebase)
   const token = localStorage.getItem('user-token')
-
   const requestOptions = {
     method: 'GET',
     headers: { 'Content-Type': 'application/json',
       "Access-Control-Allow-Origin": "*",
       "Access-Control-Allow-Methods": "DELETE, POST, GET, OPTIONS",
       "Access-Control-Allow-Headers": "Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With",
-      "Authorization": "Bearer " + token
-    },
-  };
+      "Authorization":"Bearer " + token
+    }};
 
   return fetch(process.env.REACT_APP_API_URL + '/user/user_key', requestOptions) // TODO:config.apiUrl
     .then(handleResponse)
@@ -60,7 +58,7 @@ async function storeCurrentUserkey(userKey:any, firebase:any) {
       'Content-Type' : 'application/json',
       "Authorization":"Bearer " + token
     },
-    body: JSON.stringify(userKey)
+    body: JSON.stringify({userKey})
   }
   console.log(requestOptions)
 

--- a/app/src/services/EncryptionService.ts
+++ b/app/src/services/EncryptionService.ts
@@ -3,6 +3,7 @@ import { handleAuthorization } from './ProjectServices';
 export const EncryptionServices = {
   getUserKeys,
   getEncryptedEntryKey,
+  storeCurrentUserkey,
 }
 
 async function getUserKeys(firebase: any) {
@@ -48,6 +49,28 @@ async function getEncryptedEntryKey(project_id: any, firebase: any) {
       return data.en_entry_key
     })
 }
+
+async function storeCurrentUserkey(userKey:any, firebase:any) {
+  await handleAuthorization(firebase);
+  const token = localStorage.getItem('user-token');
+
+  const requestOptions = {
+    method: 'POST',
+    headers: {
+      'Content-Type' : 'application/json',
+      "Authorization":"Bearer " + token
+    },
+    body: JSON.stringify(userKey)
+  }
+  console.log(requestOptions)
+
+  return fetch(process.env.REACT_APP_API_URL + '/users/store_user_key', requestOptions) // TODO:config.apiUrl
+    .then(handleResponse)
+    .then(data => {
+      return data
+    })
+}
+
 
 function handleResponse(response: { text: () => Promise<any>; ok: any; status: number; statusText: any; }) {
   return response.text().then((text: string) => {

--- a/app/src/services/ProjectServices.ts
+++ b/app/src/services/ProjectServices.ts
@@ -41,7 +41,7 @@ async function createProject(project_name: any, firebase: any, encryption_state:
           'Content-Type' : 'application/json',
           "Authorization":"Bearer " + token
         },
-        body: JSON.stringify( {project_name, en_entry_key} )
+        body: JSON.stringify( {project_name, encryption_state, en_entry_key} )
     }
 
     return fetch(process.env.REACT_APP_API_URL + '/projects/create', requestOptions) // TODO:config.apiUrl

--- a/app/src/services/UserServices.ts
+++ b/app/src/services/UserServices.ts
@@ -30,13 +30,13 @@ import { handleAuthorization } from './ProjectServices';
         });
 }
 
-function signup(username: string, email: string , token: string, keys:object) {
+function signup(username: string, email: string , token: string, ) {
    const requestOptions = {
         method: 'POST',
         headers: { 'Content-Type': 'application/json',
           "Authorization":"Bearer " + localStorage.getItem('user-token')
         },
-        body: JSON.stringify({username, email, keys})
+        body: JSON.stringify({username, email})
     };
 
     return fetch(process.env.REACT_APP_API_URL + `/users/create`, requestOptions)

--- a/backend/api/project_api.py
+++ b/backend/api/project_api.py
@@ -112,6 +112,7 @@ def create_project():
     print(request.json)
     if 'project_name' in request.json:
         project_name = request.json['project_name']
+        print(project_name)
     else:
         response = {'message': "Missing project name"}
         return make_response(response), 400
@@ -130,9 +131,9 @@ def create_project():
         del js['en_entry_key']
         print(js)
         if en_entry_key != '':
-
             create_new_project(requestor_email, js, en_entry_key)
         else:
+            print('not encrypt project')
             create_new_project(requestor_email, js)
     else:
         response = {'message': "Project already exists"}

--- a/backend/api/user_api.py
+++ b/backend/api/user_api.py
@@ -5,8 +5,8 @@ from middleware.auth import check_token
 # from api.methods import JSONEncoder, add_project_to_user, remove_project_from_user, remove_all_labels_of_user
 from flask import Blueprint, request, make_response, jsonify, g
 # from mongoDBInterface import get_col
-from database.user_dao import get_user_from_database_by_email, get_user_from_database_by_username, save_user_and_keys, \
-    get_all_user_email_from_database, does_user_belong_to_a_project
+from database.user_dao import get_user_from_database_by_email, get_user_from_database_by_username, save_user, \
+    save_user_key, get_all_user_email_from_database, does_user_belong_to_a_project
 
 user_api = Blueprint('user_api', __name__)
 
@@ -60,12 +60,14 @@ def get_all_users_emails():
     all_user_emails = get_all_user_email_from_database()
     return jsonify(all_user_emails), 200
 
+
 # return the role of the current user on a specific project
 @user_api.route("/projects/<project_id>/user", methods=["Get"])
 @check_token
 def get_current_user_for_project(project_id):
     collaborators = get_all_users_associated_with_a_project(project_id)
-    collaborator = next((collaborator for collaborator in collaborators if collaborator.user.email == g.requestor_email), None)
+    collaborator = next(
+        (collaborator for collaborator in collaborators if collaborator.user.email == g.requestor_email), None)
     user = {
         '_id': str(collaborator.user.id),
         # a user had admin rights if he is the owner or a admin
@@ -149,17 +151,31 @@ def create_user():
             response = {'message': "Username is already taken"}
             return make_response(response), 400
         else:
-            user_keys = request.json['keys']
-
-            print(user_keys)
             user = {
                 "username": username,
                 "email": requestor_email
             }
 
-            save_user_and_keys(user, user_keys)
+            save_user(user)
     else:
         response = {'message': "Missing username"}
+        return make_response(response), 400
+
+    # a new user created, the en_private_key is returned to the frontend
+    return '', 204
+
+
+@user_api.route("/users/store_user_key", methods=["Post"])
+@check_token
+def create_user():
+    requestor_email = g.requestor_email
+    db_user = get_user_from_database_by_email(requestor_email)
+
+    if db_user is not None:
+        keys = request.json["userKey"]
+        save_user_key(keys, db_user)
+    else:
+        response = {'message': "Missing the user"}
         return make_response(response), 400
 
     # a new user created, the en_private_key is returned to the frontend

--- a/backend/api/user_api.py
+++ b/backend/api/user_api.py
@@ -167,18 +167,18 @@ def create_user():
 
 @user_api.route("/users/store_user_key", methods=["Post"])
 @check_token
-def create_user():
+def store_user_key():
     requestor_email = g.requestor_email
     db_user = get_user_from_database_by_email(requestor_email)
 
     if db_user is not None:
         keys = request.json["userKey"]
+
         save_user_key(keys, db_user)
     else:
         response = {'message': "Missing the user"}
         return make_response(response), 400
 
-    # a new user created, the en_private_key is returned to the frontend
     return '', 204
 
 # @user_api.route("/projects/<project_name>/users/add", methods=["Post"])

--- a/backend/database/user_dao.py
+++ b/backend/database/user_dao.py
@@ -18,9 +18,13 @@ def get_user_from_database_by_username(username):
         return None
 
 
-def save_user_and_keys(user, user_keys):
-    user_key = UserKey(**user_keys)
+def save_user(user):
     user = User(**user)
+    user.save()
+
+
+def save_user_key(keys,user):
+    user_key = UserKey(**keys)
     user.key = user_key
     user.save()
 


### PR DESCRIPTION
Issue: 
Allow users to choose to create an encrypted project or not in creating a new project page.

Solution: 
- Move the UI and generation keys part from the signup page to the Header (where the creating functionality is)
-  Check if the user creates an encrypted project for the first time
-  Fix the bug of saving encryption state when creating a new project

Risk:
-  Need to test encrypted data when uploading files.
- The creating new project modal is too large. Did some research, no idea why the CSS is not working. 

Reviewed By:
Emily Yang