### PR TITLE
[CDL-24] Sharing unecrypted project to user with account

### DIFF
--- a/app/src/components/DocumentList.tsx
+++ b/app/src/components/DocumentList.tsx
@@ -87,7 +87,6 @@ const DocumentList: React.FC<DocumentListProps> = (props:DocumentListProps) => {
 	useEffect(() => {
 		documentServices.getNumberOfUnlabelledDocs(projectId, firebase)
 		.then(data => {
-			console.log(data)
 		  setContributor(data)
 		})
 	}, [])
@@ -173,7 +172,7 @@ const DocumentList: React.FC<DocumentListProps> = (props:DocumentListProps) => {
 						<InputLabel htmlFor="age-native-helper">Label</InputLabel>
 						{isNullOrUndefined(email)
 							? <div />
-							: currentUser.isAdmin
+							: currentUser.isContributor || currentUser.isAdmin
 								? <Select
 									native
 									value={user_label}

--- a/app/src/components/Project/ProjectHeader.tsx
+++ b/app/src/components/Project/ProjectHeader.tsx
@@ -1,8 +1,9 @@
-import { IonTabBar, IonTabButton, IonIcon, IonLabel, IonText } from '@ionic/react';
+import { IonTabBar, IonTabButton, IonIcon, IonLabel, IonText, useIonViewWillEnter } from '@ionic/react';
 import { analytics, folderOpen, pricetags, settings } from 'ionicons/icons';
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
 import { projectServices } from '../../services/ProjectServices';
+import { userService } from '../../services/UserServices';
 import styles from './ProjectHeader.module.css';
 
 interface ProjectHeaderProps {
@@ -20,6 +21,12 @@ const ProjectHeader: React.FC<ProjectHeaderProps> = (props: ProjectHeaderProps) 
         'state': '',
         'encryption_state': ''
     });
+    
+    const [currentUser, setCurrentUser] = useState<any>({
+        '_id': '',
+        'isAdmin': false,
+        'isContributor': false
+    });
 
     useEffect(() => {
         try {
@@ -31,6 +38,13 @@ const ProjectHeader: React.FC<ProjectHeaderProps> = (props: ProjectHeaderProps) 
             console.log(e);
         }
     }, [])
+
+    useIonViewWillEnter(() => {
+        userService.getCurrentProjectUser(id)
+            .then(data => {
+                setCurrentUser(data)
+            })
+    }, []);
     
     return (
         <div className={styles.projectDiv}>
@@ -50,7 +64,11 @@ const ProjectHeader: React.FC<ProjectHeaderProps> = (props: ProjectHeaderProps) 
                     <IonIcon icon={analytics} className={styles.tabIcon}/>
                     <IonLabel className={styles.tabLabel}>Insight</IonLabel>
                 </IonTabButton>
-                <IonTabButton tab="tab3" href={`/project/${id}/setting`} className={styles.tabButton}>
+                <IonTabButton 
+                    tab="tab3" href={`/project/${id}/setting`} 
+                    className={styles.tabButton}
+                    disabled={!currentUser.isAdmin}
+                >
                     <IonIcon icon={settings} className={styles.tabIcon}/>
                     <IonLabel className={styles.tabLabel}>Settings</IonLabel>
                 </IonTabButton>

--- a/app/src/components/SettingsUsers.tsx
+++ b/app/src/components/SettingsUsers.tsx
@@ -32,6 +32,11 @@ const SettingsUsers: React.FC<ContainerProps> = ({ project, firebase }) => {
   const [errorMessage, setErrorMessage] = useState<string>();
   const [newUser, setNewUser] = useState<string>();
 
+  const [page, setPage] = React.useState(0);
+  const handleChangePage = (event: React.MouseEvent<HTMLButtonElement> | null, newPage: number) => {
+    setPage(newPage);
+  };
+  
     var canEdit = true; // can the current user edit permissions?
 
     const initialUsers = [
@@ -41,23 +46,11 @@ const SettingsUsers: React.FC<ContainerProps> = ({ project, firebase }) => {
     const [users, setUsers] = useState(initialUsers);
     useEffect(() => {
       try {
-        projectServices.getProjectUsers(project, firebase)
+        projectServices.getProjectUsers(project, firebase, page, 5)
         .then(data => {
           setUsers(data)
         })
     } catch (e) {
-    }
-  }, [])
-
-    const [allUsers, setAllUsers] = useState(initialUsers);
-    useEffect(() => {
-      try {
-        userService.getAllUsersInDatabase() //change when creating tables of user
-        .then(data => {
-            setAllUsers(data)
-        })
-    } catch (e) {
-
     }
   }, [])
 
@@ -78,11 +71,6 @@ const SettingsUsers: React.FC<ContainerProps> = ({ project, firebase }) => {
     } catch (e) {
     }
   }
-
-  const [page, setPage] = React.useState(0);
-  const handleChangePage = (event: React.MouseEvent<HTMLButtonElement> | null, newPage: number) => {
-    setPage(newPage);
-  };
 
   return (
     <TableContainer component={Paper}>

--- a/app/src/components/SettingsUsers.tsx
+++ b/app/src/components/SettingsUsers.tsx
@@ -64,6 +64,7 @@ const SettingsUsers: React.FC<ContainerProps> = ({ project, firebase }) => {
         setNewUser("")
       })
       .catch(e => {
+        // TODO: handle the situation when the collaborator does not have account
         setErrorMessage(e);
         setShowAlert(true);
       })

--- a/app/src/services/DocumentService.ts
+++ b/app/src/services/DocumentService.ts
@@ -177,7 +177,7 @@ async function postNewComment(project_name: string, document_id: string, email:a
     })
 }
 
-function getNumberOfUnlabelledDocs(projectId:any, firebase: any) {
+async function getNumberOfUnlabelledDocs(projectId:any, firebase: any) {
   await handleAuthorization(firebase)
   const token = localStorage.getItem('user-token');
 

--- a/app/src/services/ProjectServices.ts
+++ b/app/src/services/ProjectServices.ts
@@ -118,7 +118,7 @@ function exportCsv(projectName: string) {
     })
     .catch(console.error);
 }
-async function getProjectUsers(project: string, firebase: any) {
+async function getProjectUsers(project: string, firebase: any, page: number, page_size: number) {
   await handleAuthorization(firebase)
   const token =  localStorage.getItem('user-token')
   const requestOptions = {
@@ -133,7 +133,7 @@ async function getProjectUsers(project: string, firebase: any) {
   };
 
   return fetch(process.env.REACT_APP_API_URL +
-    '/projects/' + project + '/users&page=0&page_size=20',
+    '/projects/' + project + '/users?page=' + page + '&page_size=' + page_size,
     requestOptions)
     .then(handleResponse)
     .then(data => {

--- a/app/src/services/ProjectServices.ts
+++ b/app/src/services/ProjectServices.ts
@@ -202,29 +202,23 @@ async function setProjectUsers(project: string, user: string, firebase:any) {
  }
 
  async function setUserPermissions(project: string, user: string, isAdmin: boolean, isContributor: boolean, firebase:any) {
+    await handleAuthorization(firebase)
+    const token = localStorage.getItem('user-token');
+
     const requestOptions = {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 
+          'Content-Type': 'application/json', 
+          "Authorization":"Bearer " + token
+        },
         body: JSON.stringify(
             {
                 "user": user,
                 "permissions": { "isAdmin": isAdmin, "isContributor": isContributor }
             })
     };
-
-    const token = localStorage.getItem('user-token');
-     if (firebase.auth.currentUser != null) {
-         firebase.auth.currentUser.getIdToken().then((idToken: string) => {
-             if (token !== idToken) {
-                 localStorage.setItem('user-token', idToken)
-             }
-         })
-     } else {
-         window.location.href = '/auth';
-     }
     
-    return fetch(process.env.REACT_APP_API_URL + '/projects/' + project + '/users/update?id_token=' 
-                    + localStorage.getItem('user-token'), requestOptions)
+    return fetch(process.env.REACT_APP_API_URL + '/projects/' + project + '/users/update', requestOptions)
         .then(handleResponse)
  }
 

--- a/app/src/services/UserServices.ts
+++ b/app/src/services/UserServices.ts
@@ -125,7 +125,7 @@ function getAllUsers(page_num: any, page_size: any) {
    };
     
     return fetch(process.env.REACT_APP_API_URL + '/users'
-        + '&email=' + email, requestOptions)
+        + '?email=' + email, requestOptions)
         .then(handleResponse)
         .then(data => {
             return data.user

--- a/backend/api/user_api.py
+++ b/backend/api/user_api.py
@@ -1,6 +1,7 @@
 from os import terminal_size
 from enums.user_role import UserRole
-from database.project_dao import get_all_users_associated_with_a_project, get_users_associated_with_a_project
+from database.project_dao import get_all_users_associated_with_a_project, get_users_associated_with_a_project, get_owner_of_the_project, get_project_by_id, \
+    add_collaborator_to_project
 from middleware.auth import check_token
 # from api.methods import JSONEncoder, add_project_to_user, remove_project_from_user, remove_all_labels_of_user
 from flask import Blueprint, request, make_response, jsonify, g
@@ -9,13 +10,6 @@ from database.user_dao import get_user_from_database_by_email, get_user_from_dat
     save_user_key, get_all_user_email_from_database, does_user_belong_to_a_project
 
 user_api = Blueprint('user_api', __name__)
-
-'''
-get information of a single user
-request format: /users?email=email
-FIXME email is also passed in as parameter, I don't quite understand why we allow users to get information of another user, maybe we need to change it. But requires 
-analysing of frontend first 
-'''
 
 
 @user_api.route("/users", methods=["GET"])
@@ -186,48 +180,43 @@ def store_user_key():
 
     return '', 204
 
-# @user_api.route("/projects/<project_name>/users/add", methods=["Post"])
-# # Adding a new user to a project
-# def add_user_to_project(project_name):
-#     # inputs: id_token of requestor, project name, email of user to be added to project
-#     id_token = request.args.get('id_token')
-#     requestor_email = get_email(id_token)
 
-#     invalid_token = check_id_token(id_token, requestor_email)
-#     if invalid_token is not None:
-#         return make_response(invalid_token), 400
+@user_api.route("/projects/<project_id>/users/add", methods=["Post"])
+@check_token
+# Adding a new user to a project
+def add_user_to_project(project_id):
+    # inputs: id_token of requestor, project name, email of user to be added to project
+  
+    if 'user' in request.json:
+        email = request.json['user']
+    else:
+        response = {'message': "Missing user"}
+        return make_response(response), 400
 
-#     if 'user' in request.json:
-#         email = request.json['user']
-#     else:
-#         response = {'message': "Missing user"}
-#         return make_response(response), 400
+    requestor_email = g.requestor_email
+    user_to_add_db = get_user_from_database_by_email(email)
 
-#     # check if the new user is already in the "users" collection in the "users" database
-#     user_to_add = get_col("users", "users").find_one({'email': email})
+    if user_to_add_db is None:
+        response = {'message': "User does not exist/does not have an account"}
+        return make_response(response), 400
 
-#     if user_to_add is None:
-#         response = {'message': "User does not exist/does not have an account"}
-#         return make_response(response), 400
+    # check if requestor is in the project
+    if not does_user_belong_to_a_project(requestor_email, project_id):
+        response = {'message': "Not authorised to perform this action"}
+        return make_response(response), 401
 
-#     project_user_col = get_col(project_name, "users")
-#     if project_user_col.find_one(
-#             {'email': requestor_email}) is None:  # if requestor is not in project, return unauthorised
-#         response = {'message': "Not authorised to perform this action"}
-#         return make_response(response), 401
+    # check if requestor is admin
+    if get_owner_of_the_project(get_project_by_id(project_id)).email != requestor_email:
+        response = {'message': "Forbidden to perform this action"}
+        return make_response(response), 403
 
-#     if not project_user_col.find_one({'email': requestor_email})[
-#         'isAdmin']:  # if the requestor is not an admin, return forbidden
-#         response = {'message': "Forbidden to perform this action"}
-#         return make_response(response), 403
-
-#     if project_user_col.find_one({'email': email}) is None:  # if cannot find an existing user for that email
-#         project_user_col.insert_one({'email': email, 'isAdmin': False, 'isContributor': False})
-#         add_project_to_user(email, project_name)
-#         return "", 204
-#     else:
-#         response = {'message': "That user is already in the provided project"}
-#         return make_response(response), 400
+    collaborators = get_all_users_associated_with_a_project(project_id)
+    if len(list(filter(lambda collaborator: collaborator.user.email == email, collaborators))) == 0:
+        add_collaborator_to_project(project_id, user_to_add_db)
+        return "", 204
+    else:
+        response = {'message': "That user is already in the provided project"}
+        return make_response(response), 400
 
 
 # @user_api.route("/projects/<project_name>/users/update", methods=["Put"])

--- a/backend/api/user_api.py
+++ b/backend/api/user_api.py
@@ -100,12 +100,17 @@ def get_user_infos_for_project(project_id):
     for collaborator in collaborators:
         user = collaborator.user
         dict = {
-            '_id': str(user.id),
+            'id': str(user.id),
             'email': user.email,
-            'role': collaborator.role.name
+            'isAdmin': True if collaborator.role == UserRole.OWNER else False,
+            'isContributor': True if collaborator.role == UserRole.COLLABORATOR else False
         }
         users.append(dict)
-    return jsonify(users), 200
+
+    result = {
+        'users': users
+    }
+    return jsonify(result), 200
 
 
 # @user_api.route("/user", methods=["Get"])

--- a/backend/database/project_dao.py
+++ b/backend/database/project_dao.py
@@ -43,7 +43,7 @@ def get_all_users_associated_with_a_project(project_id):
 
 
 def get_users_associated_with_a_project(project_id, page, page_limite):
-    collaborators = Project.objects(id=project_id).fields(slice__collaborators=[page * page_limite, page_limite]).get()
+    collaborators = Project.objects(id=project_id).fields(slice__collaborators=[page * page_limite, page_limite]).get().collaborators
     return collaborators
 
 

--- a/backend/database/project_dao.py
+++ b/backend/database/project_dao.py
@@ -47,6 +47,16 @@ def get_users_associated_with_a_project(project_id, page, page_limite):
     return collaborators
 
 
+def add_collaborator_to_project(project_id, db_collaborator):
+    project = Project.objects(id=project_id).get()
+    collaborator = Collaborator(user=db_collaborator, role=UserRole.READER)
+    project.collaborators.append(collaborator)
+    project.save()
+
+    db_collaborator.projects.append(project)
+    db_collaborator.save()
+
+
 def get_all_projects_of_a_user(requestor_email):
     db_user = get_user_from_database_by_email(requestor_email)
     return db_user.projects
@@ -131,14 +141,12 @@ def count_number_of_unlabelled_docs(project_id, requestor_email):
     db_data = Project.objects(id=project_id).only('data__labels').get().data
     count = 0
     for data in db_data:
-        print("check data")
         labelled = False
 
         # check if this user labelled this data 
         label_results = data.labels
         for label_result in label_results:
             if label_result.user.email == requestor_email:
-                print("labelled")
                 labelled = True
                 break
 

--- a/backend/database/project_dao.py
+++ b/backend/database/project_dao.py
@@ -57,6 +57,13 @@ def add_collaborator_to_project(project_id, db_collaborator):
     db_collaborator.save()
 
 
+def change_collaborator_permission(project_id, email, permission):
+    project = Project.objects(id=project_id).get()
+    collaborator = list(filter(lambda collaborator: collaborator.user.email == email, project.collaborators))[0]
+    collaborator.role = permission
+    project.save()
+
+
 def get_all_projects_of_a_user(requestor_email):
     db_user = get_user_from_database_by_email(requestor_email)
     return db_user.projects

--- a/backend/database/user_dao.py
+++ b/backend/database/user_dao.py
@@ -40,7 +40,6 @@ def does_user_belong_to_a_project(email, project_id):
         return False
     return True
 
-
 def get_user_public_key(requestor_email):
     db_user = get_user_from_database_by_email(requestor_email)
     return db_user.key.public_key


### PR DESCRIPTION
Sharing unencrypted projects to users with an existing account.
Allowing changes of collaborators' permission. 
Contributors can edit the label but cannot go to the setting page.

Risk:
- does not consider sharing encrypted project
- does not consider the situation when the user does not have accounts
- backend does not handle the situation when the collaborator has multiple roles. If a collaborator has both contributor and admin roles, the backend will consider the user as admin. 

Reviewed by:
Yujia 


