### PR TITLE
[CDL-27] Share encrypted project to people without publick key

### DIFF
--- a/app/src/components/Project/ProjectLabelling.tsx
+++ b/app/src/components/Project/ProjectLabelling.tsx
@@ -4,8 +4,9 @@ import {
     IonSpinner,
     useIonViewWillEnter
 } from '@ionic/react';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import '../../pages/ProjectPage.css';
+import { EncryptionServices } from '../../services/EncryptionService';
 import { userService } from '../../services/UserServices';
 import DocumentList from '../DocumentList';
 import Download from '../Download';
@@ -26,6 +27,8 @@ const ProjectLabelling: React.FC<ProjectLabellingProps> = (props: ProjectLabelli
     const [uploading, setUploading] = useState(false)
     const [uploadError, setUploadError] = useState(false);
     const [uploadErrorMsg, setUploadErrorMsg] = useState("");
+    const [encryptErrorMsg, setEncryptErrorMsg] = useState("");
+
     const { firebase,
         projectId,
         encryptStatus
@@ -48,6 +51,18 @@ const ProjectLabelling: React.FC<ProjectLabellingProps> = (props: ProjectLabelli
                 setCurrentUser(data)
             })
     }, []);
+
+    useEffect(() => {
+        if (encryptStatus) {
+            EncryptionServices.getEncryptedEntryKey(projectId, firebase)
+            .then(() => {
+                setEncryptErrorMsg("");
+            })
+            .catch(msg => {
+                setEncryptErrorMsg(msg);
+            })
+        }
+    }, [encryptStatus]);
 
     return (
         <div>
@@ -82,11 +97,20 @@ const ProjectLabelling: React.FC<ProjectLabellingProps> = (props: ProjectLabelli
                             <IonTitle>Uploading...</IonTitle>
                         </IonToolbar>
                         <br />
-                        <IonSpinner class="spinner" name="crescent" color="primary" /></div>
-                    : <DocumentList projectId={projectId}
-                                    firebase={firebase}
-                                    currentUser={currentUser}
-                                    encryptStatus={encryptStatus}/>}
+                        <IonSpinner class="spinner" name="crescent" color="primary" /></div> :
+                    encryptErrorMsg ?
+                        <div className="container">
+                            <IonToolbar>
+                                <IonTitle>Waiting for the owner to share project data...</IonTitle>
+                            </IonToolbar>
+                            <br />
+                            <IonSpinner class="spinner" name="crescent" color="primary" />
+                        </div> :
+                        <DocumentList projectId={projectId}
+                            firebase={firebase}
+                            currentUser={currentUser}
+                            encryptStatus={encryptStatus} />
+                }
             </div>
         </div>
     );

--- a/app/src/components/SettingsUser.tsx
+++ b/app/src/components/SettingsUser.tsx
@@ -16,11 +16,13 @@ interface ContainerProps {
   isContributor: boolean;
   isAdmin: boolean;
   canEdit: boolean;
-  firebase:any
+  firebase:any;
+  needPublicKey: boolean;
+  needEntryKey: boolean;
 }
 
 
-const SettingsUser: React.FC<ContainerProps> = ({ project, user, isContributor, isAdmin, canEdit, firebase }) => {
+const SettingsUser: React.FC<ContainerProps> = ({ project, user, isContributor, isAdmin, canEdit, firebase, needPublicKey, needEntryKey }) => {
 
   const [showPermissions, setShowPermissions] = useState(false);
   const [showError, setShowError] = useState(false);
@@ -133,10 +135,13 @@ const SettingsUser: React.FC<ContainerProps> = ({ project, user, isContributor, 
             <IonIcon title="" icon={eyeOutline} hidden={localIsAdmin || localIsContributor}></IonIcon>
           </Tooltip>
       </TableCell>
-      <TableCell align="right" style={ {width: '60px'} }>
-        <IonButton fill="clear" onClick={() => setShowPermissions(true)} disabled={!canEdit}>
-          Edit
-        </IonButton>
+      <TableCell align="right" style={{ width: '60px' }}>
+        {
+          needPublicKey ? <div style={{ color: 'red' }}>Waiting for collaborator to provide key phrase to decrypt the project</div> :
+            <IonButton fill="clear" onClick={() => setShowPermissions(true)} disabled={!canEdit}>
+              Edit
+            </IonButton>
+        }
       </TableCell>
       {alert}
       {errorAlert}

--- a/app/src/components/SettingsUser.tsx
+++ b/app/src/components/SettingsUser.tsx
@@ -19,10 +19,11 @@ interface ContainerProps {
   firebase:any;
   needPublicKey: boolean;
   needEntryKey: boolean;
+  handleAssignData: any;
 }
 
 
-const SettingsUser: React.FC<ContainerProps> = ({ project, user, isContributor, isAdmin, canEdit, firebase, needPublicKey, needEntryKey }) => {
+const SettingsUser: React.FC<ContainerProps> = ({ project, user, isContributor, isAdmin, canEdit, firebase, needPublicKey, needEntryKey, handleAssignData }) => {
 
   const [showPermissions, setShowPermissions] = useState(false);
   const [showError, setShowError] = useState(false);
@@ -138,9 +139,13 @@ const SettingsUser: React.FC<ContainerProps> = ({ project, user, isContributor, 
       <TableCell align="right" style={{ width: '60px' }}>
         {
           needPublicKey ? <div style={{ color: 'red' }}>Waiting for collaborator to provide key phrase to decrypt the project</div> :
-            <IonButton fill="clear" onClick={() => setShowPermissions(true)} disabled={!canEdit}>
-              Edit
-            </IonButton>
+            needEntryKey ?
+              <IonButton style={{ color: 'red' }} fill="clear" onClick={() => handleAssignData(user)}>
+                Assign data
+              </IonButton> :
+              <IonButton fill="clear" onClick={() => setShowPermissions(true)} disabled={!canEdit}>
+                Edit
+              </IonButton>
         }
       </TableCell>
       {alert}

--- a/app/src/components/SettingsUsers.tsx
+++ b/app/src/components/SettingsUsers.tsx
@@ -41,7 +41,7 @@ const SettingsUsers: React.FC<ContainerProps> = ({ project, firebase }) => {
     var canEdit = true; // can the current user edit permissions?
 
     const initialUsers = [
-        { id: 0, email: 'No users', isAdmin: false, isContributor: false }
+        { id: 0, email: 'No users', isAdmin: false, isContributor: false, needPublicKey: false, needEntryKey: false }
     ]
 
     const [users, setUsers] = useState(initialUsers);
@@ -60,17 +60,22 @@ const SettingsUsers: React.FC<ContainerProps> = ({ project, firebase }) => {
       // check if user exists
       userService.getUser(user)
       .then(async () => {
+        var needPublicKey = false;
         const isEncrypted = await projectServices.isProjectEncrypted(project, firebase);
         if (isEncrypted) {
-          // get public key for the collaborator, this will throw exception if collaborator does 
-          // not have a key 
-          const collaboratorKey = await EncryptionServices.getUserKeys(firebase, user)
-          projectServices.setProjectUsers(project, user, firebase, collaboratorKey.public_key);
+          try {
+            const collaboratorKey = await EncryptionServices.getUserKeys(firebase, user);                      
+            projectServices.setProjectUsers(project, user, firebase, collaboratorKey.public_key);
+          } catch {
+            // handle situation when collaborator does not have user key 
+            projectServices.setProjectUsers(project, user, firebase);
+            needPublicKey = true;
+          }
         }
         else {
           projectServices.setProjectUsers(project, user, firebase);
         }
-        setUsers([...users, {id: 0, email: user, isAdmin: false, isContributor: false}])
+        setUsers([...users, {id: 0, email: user, isAdmin: false, isContributor: false, needPublicKey: needPublicKey, needEntryKey: false}])
         setNewUser("")
       })
       .catch(e => {
@@ -129,7 +134,10 @@ const SettingsUsers: React.FC<ContainerProps> = ({ project, firebase }) => {
                             isAdmin={user.isAdmin}
                             isContributor={user.isContributor}
                             canEdit={canEdit}
-                            firebase={firebase}/>
+                            firebase={firebase}
+                            needPublicKey={user.needPublicKey}
+                            needEntryKey={user.needEntryKey}
+              />
             );
           })}
         </TableBody>

--- a/app/src/components/SettingsUsers.tsx
+++ b/app/src/components/SettingsUsers.tsx
@@ -89,6 +89,14 @@ const SettingsUsers: React.FC<ContainerProps> = ({ project, firebase }) => {
     }
   }
 
+  async function handleAssignDataToCollaborator(collaborator_email: string) {
+    await projectServices.addEntryKeyToCollaborator(project, collaborator_email, firebase);
+    projectServices.getProjectUsers(project, firebase, page, 5)
+      .then(data => {
+        setUsers(data)
+      })
+  }
+
   return (
     <TableContainer component={Paper}>
 
@@ -137,6 +145,7 @@ const SettingsUsers: React.FC<ContainerProps> = ({ project, firebase }) => {
                             firebase={firebase}
                             needPublicKey={user.needPublicKey}
                             needEntryKey={user.needEntryKey}
+                            handleAssignData={handleAssignDataToCollaborator}
               />
             );
           })}

--- a/app/src/helpers/encryption.ts
+++ b/app/src/helpers/encryption.ts
@@ -8,12 +8,19 @@ const forge = require('node-forge')
   ,  pki = forge.pki;
 
 export const EncryptedHelpers = {
+  generateHashPhrase,
   generateKeys,
   generateEncryptedEntryKey,
   encryptEntryKey,
+  decryptEncryptedPrivateKey,
   encryptData,
   decryptData,
   getEntryKey
+}
+
+function generateHashPhrase(phrase: string, salt: string) {
+  const hashPhrase = crypto.createHmac("sha256", salt).update(phrase).digest("base64").toString();
+  return hashPhrase;
 }
 
 async function generateKeys(phrase: string) {

--- a/app/src/pages/MainPage.css
+++ b/app/src/pages/MainPage.css
@@ -7,6 +7,10 @@
     width:20%;
   }
 
+  .projectCard :hover {
+    cursor: pointer;
+  }
+
   .container {
     text-align: center;
     position: relative;

--- a/app/src/pages/MainPage.tsx
+++ b/app/src/pages/MainPage.tsx
@@ -226,7 +226,7 @@ const MainPage: React.FC<MainPageProps> = (props: MainPageProps) => {
         </div>
       </IonContent>
 
-      {/*Create project window */}
+      {/*Asking for key phrase window */}
       <IonModal
         isOpen={showKeyPhrasePopup}
         cssClass='createProject'

--- a/backend/database/project_dao.py
+++ b/backend/database/project_dao.py
@@ -58,6 +58,12 @@ def add_collaborator_to_encrypt_project(project_id, db_collaborator, en_entry_ke
     db_collaborator.save()
 
 
+def add_entry_key_for_collaborator_in_encrypt_project(project_id, db_collaborator, en_entry_key):
+    db_project = Project.objects(id=project_id).get()
+    db_project.collaborators[db_project.collaborators.index(db_collaborator)].entry_key = en_entry_key
+    db_project.save()
+
+
 def add_collaborator_to_project(project_id, db_collaborator):
     project = Project.objects(id=project_id).get()
     collaborator = Collaborator(user=db_collaborator, role=UserRole.READER)


### PR DESCRIPTION
Share encrypted projects to collaborators when they have accounts but do not have public keys.

Flow from project owner side:
- share project -> user does not have public key -> show error msg saying "waiting for the collaborator to provide public key" -> collaborator provides key, show button "assign data" 

Flow from collaborator side:
- see the encrypted project -> click on it -> seeing popup asking for key phrase -> provide key phrase -> going into project -> see msg "waiting for owner to assign data".

Added flow in general when the user has public key in the database but not in local storage 
- click encrypted project -> see a popup asking for key phrase -> check the correctness of key phrase -> go into the project

Risk:
sharing encrypted project

Reviewed by:
Yujia 
